### PR TITLE
Fix fonts in Firefox

### DIFF
--- a/assets/odi-app.css
+++ b/assets/odi-app.css
@@ -62,7 +62,6 @@ body{
     color: white;
     padding-right: 2%;
     padding-left: 2%;
-    font-family: HelveticaNeue;
     font-size: 3rem;
     display: flex;
     align-items: center;
@@ -149,7 +148,6 @@ summary:focus {
 
 
 .big-text {
-  font-family: HelveticaNeue;
   font-size: 20px;
   font-weight: 500;
   font-style: normal;


### PR DESCRIPTION
Header/"big text" fonts are broken in Firefox. There's no need to override `font-family` — the correct `font-family` is inherited from `body`.

Before:
![image](https://user-images.githubusercontent.com/4970459/58188541-b4262d80-7cb0-11e9-9a85-a6e0717adff7.png)

After:
![image](https://user-images.githubusercontent.com/4970459/58188548-b7b9b480-7cb0-11e9-9360-fe101ccc737a.png)
